### PR TITLE
fix: Move to resource and operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ https://serpapi.com/blog/tag/n8n/
 
 ## License
 
-[MIT](https://github.com/n8n-io/n8n-nodes-starter/blob/master/LICENSE.md)
+[MIT](https://github.com/alexbarron/n8n-nodes-serpapi/blob/master/LICENSE.md)

--- a/nodes/SerpApi/SerpApi.node.ts
+++ b/nodes/SerpApi/SerpApi.node.ts
@@ -1,3 +1,4 @@
+/* eslint-disable n8n-nodes-base/node-param-operation-option-action-miscased */
 import { INodeType, INodeTypeDescription, NodeConnectionType } from 'n8n-workflow';
 
 import {
@@ -36,7 +37,7 @@ export class SerpApi implements INodeType {
 		icon: 'file:serpapi.svg',
 		group: ['transform'],
 		version: 1,
-		subtitle: '={{$parameter["resource"]}}',
+		subtitle: '={{$parameter["operation"]}}',
 		description: "Get live Google Search data and more from SerpApi's official node",
 		defaults: {
 			name: 'SerpApi',
@@ -59,10 +60,22 @@ export class SerpApi implements INodeType {
 		},
 
 		properties: [
-			// Resources and operations will go here
 			{
 				displayName: 'Resource',
 				name: 'resource',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Search',
+						value: 'search',
+					}
+				],
+				default: 'search',
+			},
+			{
+				displayName: 'Operation',
+				name: 'operation',
 				type: 'options',
 				noDataExpression: true,
 				options: [

--- a/nodes/SerpApi/descriptions/BaiduSearchDescription.ts
+++ b/nodes/SerpApi/descriptions/BaiduSearchDescription.ts
@@ -19,7 +19,7 @@ export const baiduSearchFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['baidu'],
+				operation: ['baidu'],
 			},
 		},
 	},
@@ -31,7 +31,7 @@ export const baiduSearchFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['baidu'],
+				operation: ['baidu'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/BingImagesDescription.ts
+++ b/nodes/SerpApi/descriptions/BingImagesDescription.ts
@@ -19,7 +19,7 @@ export const bingImagesFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['bing_images'],
+				operation: ['bing_images'],
 			},
 		},
 	},
@@ -38,7 +38,7 @@ export const bingImagesFields: INodeProperties[] = [
 		},
 		displayOptions: {
 			show: {
-				resource: ['bing_images'],
+				operation: ['bing_images'],
 			},
 		},
 		type: 'options',
@@ -91,7 +91,7 @@ export const bingImagesFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['bing_images'],
+				operation: ['bing_images'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/BingSearchDescription.ts
+++ b/nodes/SerpApi/descriptions/BingSearchDescription.ts
@@ -19,7 +19,7 @@ export const bingSearchFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['bing'],
+				operation: ['bing'],
 			},
 		},
 	},
@@ -39,7 +39,7 @@ export const bingSearchFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['bing'],
+				operation: ['bing'],
 			},
 		},
 	},
@@ -51,7 +51,7 @@ export const bingSearchFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['bing'],
+				operation: ['bing'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/DuckDuckGoSearchDescription.ts
+++ b/nodes/SerpApi/descriptions/DuckDuckGoSearchDescription.ts
@@ -18,7 +18,7 @@ export const duckDuckGoSearchFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['duckduckgo'],
+				operation: ['duckduckgo'],
 			},
 		},
 	},
@@ -30,7 +30,7 @@ export const duckDuckGoSearchFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['duckduckgo'],
+				operation: ['duckduckgo'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/EbaySearchDescription.ts
+++ b/nodes/SerpApi/descriptions/EbaySearchDescription.ts
@@ -19,7 +19,7 @@ export const ebaySearchFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['ebay'],
+				operation: ['ebay'],
 			},
 		},
 	},
@@ -38,7 +38,7 @@ export const ebaySearchFields: INodeProperties[] = [
 		type: 'options',
 		displayOptions: {
 			show: {
-				resource: ['ebay'],
+				operation: ['ebay'],
 			},
 		},
 		options: [
@@ -120,7 +120,7 @@ export const ebaySearchFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['ebay'],
+				operation: ['ebay'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleAutocompleteDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleAutocompleteDescription.ts
@@ -20,7 +20,7 @@ export const googleAutocompleteFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_autocomplete'],
+				operation: ['google_autocomplete'],
 			},
 		},
 	},
@@ -32,7 +32,7 @@ export const googleAutocompleteFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_autocomplete'],
+				operation: ['google_autocomplete'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleFlightsDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleFlightsDescription.ts
@@ -19,7 +19,7 @@ export const googleFlightsFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_flights'],
+				operation: ['google_flights'],
 			},
 		},
 	},
@@ -39,7 +39,7 @@ export const googleFlightsFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_flights'],
+				operation: ['google_flights'],
 			},
 		},
 	},
@@ -58,7 +58,7 @@ export const googleFlightsFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_flights'],
+				operation: ['google_flights'],
 			},
 		},
 	},
@@ -78,7 +78,7 @@ export const googleFlightsFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_flights'],
+				operation: ['google_flights'],
 			},
 		},
 	},
@@ -112,7 +112,7 @@ export const googleFlightsFields: INodeProperties[] = [
 		],
 		displayOptions: {
 			show: {
-				resource: ['google_flights'],
+				operation: ['google_flights'],
 			},
 		},
 	},
@@ -124,7 +124,7 @@ export const googleFlightsFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_flights'],
+				operation: ['google_flights'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleImagesDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleImagesDescription.ts
@@ -19,7 +19,7 @@ export const googleImagesFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_images'],
+				operation: ['google_images'],
 			},
 		},
 	},
@@ -31,7 +31,7 @@ export const googleImagesFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_images'],
+				operation: ['google_images'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleJobsDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleJobsDescription.ts
@@ -19,7 +19,7 @@ export const googleJobsFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_jobs'],
+				operation: ['google_jobs'],
 			},
 		},
 	},
@@ -31,7 +31,7 @@ export const googleJobsFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_jobs'],
+				operation: ['google_jobs'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleLensDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleLensDescription.ts
@@ -19,7 +19,7 @@ export const googleLensFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_lens'],
+				operation: ['google_lens'],
 			},
 		},
 	},
@@ -31,7 +31,7 @@ export const googleLensFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_lens'],
+				operation: ['google_lens'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleLightDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleLightDescription.ts
@@ -19,7 +19,7 @@ export const googleLightFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_light'],
+				operation: ['google_light'],
 			},
 		},
 	},
@@ -39,7 +39,7 @@ export const googleLightFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_light'],
+				operation: ['google_light'],
 			},
 		},
 	},
@@ -51,7 +51,7 @@ export const googleLightFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_light'],
+				operation: ['google_light'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleLocalDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleLocalDescription.ts
@@ -19,7 +19,7 @@ export const googleLocalFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_local'],
+				operation: ['google_local'],
 			},
 		},
 	},
@@ -39,7 +39,7 @@ export const googleLocalFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_local'],
+				operation: ['google_local'],
 			},
 		},
 	},
@@ -51,7 +51,7 @@ export const googleLocalFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_local'],
+				operation: ['google_local'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleMapsDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleMapsDescription.ts
@@ -18,7 +18,7 @@ export const googleMapsFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_maps'],
+				operation: ['google_maps'],
 			},
 		},
 	},
@@ -48,7 +48,7 @@ export const googleMapsFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_maps'],
+				operation: ['google_maps'],
 			},
 		},
 	},
@@ -68,7 +68,7 @@ export const googleMapsFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_maps'],
+				operation: ['google_maps'],
 			},
 		},
 	},
@@ -80,7 +80,7 @@ export const googleMapsFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_maps'],
+				operation: ['google_maps'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleMapsDirectionsDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleMapsDirectionsDescription.ts
@@ -19,7 +19,7 @@ export const googleMapsDirectionsFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_maps_directions'],
+				operation: ['google_maps_directions'],
 			},
 		},
 	},
@@ -39,7 +39,7 @@ export const googleMapsDirectionsFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_maps_directions'],
+				operation: ['google_maps_directions'],
 			},
 		},
 	},
@@ -51,7 +51,7 @@ export const googleMapsDirectionsFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_maps_directions'],
+				operation: ['google_maps_directions'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleMapsReviewsDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleMapsReviewsDescription.ts
@@ -19,7 +19,7 @@ export const googleMapsReviewsFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_maps_reviews'],
+				operation: ['google_maps_reviews'],
 			},
 		},
 	},
@@ -39,7 +39,7 @@ export const googleMapsReviewsFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_maps_reviews'],
+				operation: ['google_maps_reviews'],
 			},
 		},
 	},
@@ -51,7 +51,7 @@ export const googleMapsReviewsFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_maps_reviews'],
+				operation: ['google_maps_reviews'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleNewsDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleNewsDescription.ts
@@ -19,7 +19,7 @@ export const googleNewsFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_news'],
+				operation: ['google_news'],
 			},
 		},
 	},
@@ -31,7 +31,7 @@ export const googleNewsFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_news'],
+				operation: ['google_news'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleProductDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleProductDescription.ts
@@ -20,7 +20,7 @@ export const googleProductFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_product'],
+				operation: ['google_product'],
 			},
 		},
 	},
@@ -32,7 +32,7 @@ export const googleProductFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_product'],
+				operation: ['google_product'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleScholarDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleScholarDescription.ts
@@ -19,7 +19,7 @@ export const googleScholarFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_scholar'],
+				operation: ['google_scholar'],
 			},
 		},
 	},
@@ -31,7 +31,7 @@ export const googleScholarFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_scholar'],
+				operation: ['google_scholar'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleSearchDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleSearchDescription.ts
@@ -19,7 +19,7 @@ export const googleSearchFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google'],
+				operation: ['google'],
 			},
 		},
 	},
@@ -39,7 +39,7 @@ export const googleSearchFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google'],
+				operation: ['google'],
 			},
 		},
 	},
@@ -51,7 +51,7 @@ export const googleSearchFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google'],
+				operation: ['google'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleShoppingDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleShoppingDescription.ts
@@ -19,7 +19,7 @@ export const googleShoppingFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_shopping'],
+				operation: ['google_shopping'],
 			},
 		},
 	},
@@ -39,7 +39,7 @@ export const googleShoppingFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_shopping'],
+				operation: ['google_shopping'],
 			},
 		},
 	},
@@ -51,7 +51,7 @@ export const googleShoppingFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_shopping'],
+				operation: ['google_shopping'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleTrendsDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleTrendsDescription.ts
@@ -20,7 +20,7 @@ export const googleTrendsFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_trends'],
+				operation: ['google_trends'],
 			},
 		},
 	},
@@ -32,7 +32,7 @@ export const googleTrendsFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_trends'],
+				operation: ['google_trends'],
 			},
 		},
 		options: [

--- a/nodes/SerpApi/descriptions/GoogleVideosDescription.ts
+++ b/nodes/SerpApi/descriptions/GoogleVideosDescription.ts
@@ -19,7 +19,7 @@ export const googleVideosFields: INodeProperties[] = [
 		required: true,
 		displayOptions: {
 			show: {
-				resource: ['google_videos'],
+				operation: ['google_videos'],
 			},
 		},
 	},
@@ -39,7 +39,7 @@ export const googleVideosFields: INodeProperties[] = [
 		type: 'string',
 		displayOptions: {
 			show: {
-				resource: ['google_videos'],
+				operation: ['google_videos'],
 			},
 		},
 	},
@@ -51,7 +51,7 @@ export const googleVideosFields: INodeProperties[] = [
 		placeholder: 'Add Field',
 		displayOptions: {
 			show: {
-				resource: ['google_videos'],
+				operation: ['google_videos'],
 			},
 		},
 		options: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-serpapi",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-serpapi",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/parser": "~5.45",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-serpapi",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Official n8n node for SerpApi",
   "keywords": [
     "n8n-community-node-package"


### PR DESCRIPTION
👋🏻 Jon from the n8n nodes team here,

This PR updates the node to use the Resource > Operation pattern we use for nodes which will allow the actions to be displayed when adding the community node.

I have also bumped the version number for you and changed the MIT license docs to point to this repo. Once published let myself or Shireen know and we can make this available to the cloud users.

One warning... Because of this change this update will break the node for existing users so maybe the major version should be changed and a notice added but it depends on how long the node has been available for as to how many users may be impacted.